### PR TITLE
Add APIs for contract review and rule management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,9 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { MongooseConfigService } from './database/mongoose-config.service';
 import { DatabaseConfig } from './database/config/database-config.type';
 import { StandardClausesModule } from './modules/standard-clauses/standard-clauses.module';
+import { ContractModule } from './modules/contract/contract.module';
+import { TemplatesModule } from './templates/templates.module';
+import { RulesModule } from './modules/rules/rules.module';
 
 // <database-block>
 const infrastructureDatabaseModule = (databaseConfig() as DatabaseConfig)
@@ -94,6 +97,9 @@ const infrastructureDatabaseModule = (databaseConfig() as DatabaseConfig)
     MailerModule,
     HomeModule,
     StandardClausesModule,
+    ContractModule,
+    TemplatesModule,
+    RulesModule,
   ],
 })
 export class AppModule {}

--- a/src/entities/risk-flag.entity.ts
+++ b/src/entities/risk-flag.entity.ts
@@ -26,6 +26,12 @@ export class RiskFlag {
   @Column({ type: 'text', nullable: true })
   suggestedText: string;
 
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @Column({ enum: ['open', 'resolved', 'ignored'], default: 'open', type: 'enum' })
+  status: 'open' | 'resolved' | 'ignored';
+
   @Column({ default: false })
   isResolved: boolean;
 

--- a/src/entities/rule.entity.ts
+++ b/src/entities/rule.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('rules')
+export class Rule {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty()
+  @Column()
+  name: string;
+
+  @ApiProperty({ required: false })
+  @Column({ nullable: true })
+  description?: string;
+
+  @ApiProperty({ required: false })
+  @Column({ nullable: true })
+  pattern?: string;
+
+  @ApiProperty({ required: false, type: Number })
+  @Column({ type: 'float', nullable: true })
+  similarityThreshold?: number;
+
+  @ApiProperty({ required: false, type: Number })
+  @Column({ type: 'float', nullable: true })
+  deviationAllowedPct?: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/entities/standard-clause.entity.ts
+++ b/src/entities/standard-clause.entity.ts
@@ -16,6 +16,10 @@ export class StandardClause {
   type: string;
 
   @ApiProperty()
+  @Column()
+  contractType: string;
+
+  @ApiProperty()
   @Column('text')
   text: string;
 
@@ -27,9 +31,9 @@ export class StandardClause {
   @Column({ nullable: true })
   version?: string;
 
-  @ApiProperty()
-  @Column('text', { nullable: true })
-  allowedDeviations?: string;
+  @ApiProperty({ required: false, type: Number })
+  @Column({ type: 'int', nullable: true })
+  allowedDeviations?: number;
 
   @ApiProperty()
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })

--- a/src/modules/contract/contract.service.ts
+++ b/src/modules/contract/contract.service.ts
@@ -140,9 +140,42 @@ export class ContractService {
     return contract.riskFlags;
   }
 
+  async getAnalysis(id: string): Promise<{ summaries: Summary[]; riskFlags: RiskFlag[] }> {
+    const contract = await this.findOne(id);
+    return {
+      summaries: contract.summaries,
+      riskFlags: contract.riskFlags,
+    };
+  }
+
   async getContractQnA(id: string): Promise<QnA[]> {
     const contract = await this.findOne(id);
     return contract.qnas;
+  }
+
+  async updateRiskFlag(
+    contractId: string,
+    riskId: string,
+    status: 'open' | 'resolved' | 'ignored',
+    notes?: string,
+  ): Promise<RiskFlag> {
+    await this.findOne(contractId);
+    const riskFlag = await this.riskFlagRepository.findOne({ where: { id: riskId } });
+    if (!riskFlag) {
+      throw new NotFoundException(`Risk flag with ID ${riskId} not found`);
+    }
+    Object.assign(riskFlag, { status, notes });
+    return this.riskFlagRepository.save(riskFlag);
+  }
+
+  async exportAnalysis(id: string): Promise<any> {
+    const contract = await this.findOne(id);
+    return {
+      contract,
+      summaries: contract.summaries,
+      riskFlags: contract.riskFlags,
+      qna: contract.qnas,
+    };
   }
 
   async getContractReviews(id: string): Promise<HumanReview[]> {

--- a/src/modules/contract/dto/update-risk-flag.dto.ts
+++ b/src/modules/contract/dto/update-risk-flag.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class UpdateRiskFlagDto {
+  @ApiProperty({ enum: ['open', 'resolved', 'ignored'] })
+  @IsEnum(['open', 'resolved', 'ignored'])
+  status: 'open' | 'resolved' | 'ignored';
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/modules/rules/dto/create-rule.dto.ts
+++ b/src/modules/rules/dto/create-rule.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsNumber, Max, Min } from 'class-validator';
+
+export class CreateRuleDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  pattern?: string;
+
+  @ApiProperty({ required: false, type: Number })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  similarityThreshold?: number;
+
+  @ApiProperty({ required: false, type: Number })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  deviationAllowedPct?: number;
+}

--- a/src/modules/rules/dto/update-rule.dto.ts
+++ b/src/modules/rules/dto/update-rule.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRuleDto } from './create-rule.dto';
+
+export class UpdateRuleDto extends PartialType(CreateRuleDto) {}

--- a/src/modules/rules/rules.controller.ts
+++ b/src/modules/rules/rules.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RulesService } from './rules.service';
+import { CreateRuleDto } from './dto/create-rule.dto';
+import { UpdateRuleDto } from './dto/update-rule.dto';
+import { Rule } from '../../entities/rule.entity';
+
+@ApiTags('rules')
+@Controller('rules')
+export class RulesController {
+  constructor(private readonly rulesService: RulesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List rules' })
+  @ApiResponse({ status: 200, type: [Rule] })
+  findAll() {
+    return this.rulesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get rule by id' })
+  @ApiResponse({ status: 200, type: Rule })
+  findOne(@Param('id') id: string) {
+    return this.rulesService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create rule' })
+  @ApiResponse({ status: 201, type: Rule })
+  create(@Body() dto: CreateRuleDto) {
+    return this.rulesService.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update rule' })
+  @ApiResponse({ status: 200, type: Rule })
+  update(@Param('id') id: string, @Body() dto: UpdateRuleDto) {
+    return this.rulesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete rule' })
+  @ApiResponse({ status: 200 })
+  remove(@Param('id') id: string) {
+    return this.rulesService.remove(id);
+  }
+}

--- a/src/modules/rules/rules.module.ts
+++ b/src/modules/rules/rules.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Rule } from '../../entities/rule.entity';
+import { RulesService } from './rules.service';
+import { RulesController } from './rules.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Rule])],
+  controllers: [RulesController],
+  providers: [RulesService],
+  exports: [RulesService],
+})
+export class RulesModule {}

--- a/src/modules/rules/rules.service.ts
+++ b/src/modules/rules/rules.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Rule } from '../../entities/rule.entity';
+import { CreateRuleDto } from './dto/create-rule.dto';
+import { UpdateRuleDto } from './dto/update-rule.dto';
+
+@Injectable()
+export class RulesService {
+  constructor(
+    @InjectRepository(Rule)
+    private readonly ruleRepository: Repository<Rule>,
+  ) {}
+
+  private validateThresholds(dto: CreateRuleDto | UpdateRuleDto) {
+    if (dto.similarityThreshold !== undefined && dto.deviationAllowedPct !== undefined) {
+      throw new BadRequestException('similarityThreshold and deviationAllowedPct cannot both be set');
+    }
+    if (dto.pattern) {
+      try {
+        // eslint-disable-next-line no-new
+        new RegExp(dto.pattern);
+      } catch (e) {
+        throw new BadRequestException('pattern is not a valid regex');
+      }
+    }
+  }
+
+  async create(dto: CreateRuleDto): Promise<Rule> {
+    this.validateThresholds(dto);
+    const rule = this.ruleRepository.create(dto);
+    return this.ruleRepository.save(rule);
+  }
+
+  async findAll(): Promise<Rule[]> {
+    return this.ruleRepository.find();
+  }
+
+  async findOne(id: string): Promise<Rule> {
+    const rule = await this.ruleRepository.findOne({ where: { id } });
+    if (!rule) {
+      throw new NotFoundException(`Rule with ID ${id} not found`);
+    }
+    return rule;
+  }
+
+  async update(id: string, dto: UpdateRuleDto): Promise<Rule> {
+    const rule = await this.findOne(id);
+    this.validateThresholds(dto);
+    Object.assign(rule, dto);
+    return this.ruleRepository.save(rule);
+  }
+
+  async remove(id: string): Promise<void> {
+    const rule = await this.findOne(id);
+    await this.ruleRepository.remove(rule);
+  }
+}

--- a/src/modules/standard-clauses/dto/create-standard-clause.dto.ts
+++ b/src/modules/standard-clauses/dto/create-standard-clause.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsNumber,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class CreateStandardClauseDto {
   @ApiProperty()
@@ -11,6 +18,11 @@ export class CreateStandardClauseDto {
   @IsNotEmpty()
   @IsString()
   type: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  contractType: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -27,8 +39,10 @@ export class CreateStandardClauseDto {
   @IsString()
   version?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Number })
   @IsOptional()
-  @IsString()
-  allowedDeviations?: string;
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  allowedDeviations?: number;
 } 

--- a/src/modules/standard-clauses/dto/update-standard-clause.dto.ts
+++ b/src/modules/standard-clauses/dto/update-standard-clause.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateStandardClauseDto } from './create-standard-clause.dto';
+
+export class UpdateStandardClauseDto extends PartialType(CreateStandardClauseDto) {}

--- a/src/modules/standard-clauses/standard-clauses.controller.ts
+++ b/src/modules/standard-clauses/standard-clauses.controller.ts
@@ -4,6 +4,7 @@ import { StandardClausesService } from './standard-clauses.service';
 import { CreateStandardClauseDto } from './dto/create-standard-clause.dto';
 import { StandardClause } from '../../entities/standard-clause.entity';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { UpdateStandardClauseDto } from './dto/update-standard-clause.dto';
 
 @ApiTags('standard-clauses')
 @Controller('standard-clauses')
@@ -41,13 +42,20 @@ export class StandardClausesController {
     return this.standardClausesService.findByType(type);
   }
 
+  @Get('contract-type/:contractType')
+  @ApiOperation({ summary: 'Get standard clauses by contract type' })
+  @ApiResponse({ status: 200, description: 'Return clauses for the contract type.', type: [StandardClause] })
+  findByContractType(@Param('contractType') contractType: string): Promise<StandardClause[]> {
+    return this.standardClausesService.findByContractType(contractType);
+  }
+
   @Patch(':id')
   @ApiOperation({ summary: 'Update a standard clause' })
   @ApiResponse({ status: 200, description: 'The standard clause has been successfully updated.', type: StandardClause })
   @ApiResponse({ status: 404, description: 'Standard clause not found.' })
   update(
     @Param('id') id: string,
-    @Body() updateStandardClauseDto: Partial<CreateStandardClauseDto>,
+    @Body() updateStandardClauseDto: UpdateStandardClauseDto,
   ): Promise<StandardClause> {
     return this.standardClausesService.update(+id, updateStandardClauseDto);
   }

--- a/src/modules/standard-clauses/standard-clauses.service.ts
+++ b/src/modules/standard-clauses/standard-clauses.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { StandardClause } from '../../entities/standard-clause.entity';
 import { CreateStandardClauseDto } from './dto/create-standard-clause.dto';
+import { UpdateStandardClauseDto } from './dto/update-standard-clause.dto';
 
 @Injectable()
 export class StandardClausesService {
@@ -32,7 +33,11 @@ export class StandardClausesService {
     return this.standardClauseRepository.find({ where: { type } });
   }
 
-  async update(id: number, updateStandardClauseDto: Partial<CreateStandardClauseDto>): Promise<StandardClause> {
+  async findByContractType(contractType: string): Promise<StandardClause[]> {
+    return this.standardClauseRepository.find({ where: { contractType } });
+  }
+
+  async update(id: number, updateStandardClauseDto: UpdateStandardClauseDto): Promise<StandardClause> {
     const standardClause = await this.findOne(id);
     Object.assign(standardClause, updateStandardClauseDto);
     return this.standardClauseRepository.save(standardClause);

--- a/src/templates/templates.service.ts
+++ b/src/templates/templates.service.ts
@@ -13,7 +13,10 @@ export class TemplatesService {
   ) {}
 
   async create(createStandardClauseDto: CreateStandardClauseDto): Promise<StandardClause> {
-    const clause = this.standardClauseRepository.create(createStandardClauseDto);
+    const clause = this.standardClauseRepository.create({
+      isActive: true,
+      ...createStandardClauseDto,
+    });
     return this.standardClauseRepository.save(clause);
   }
 


### PR DESCRIPTION
## Summary
- implement contract review endpoints with chat export and risk updates
- extend standard clauses with contractType and numeric allowedDeviations
- provide rule entity with CRUD module and validation
- update template creation and application module

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm run lint -- --fix` *(fails: module not found)*
- `npm test` *(fails: jest not found)*