### PR TITLE
Add tests for template module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "test:e2e": "env-cmd jest --config ./test/jest-e2e.json",
     "test:e2e:document:docker": "docker compose -f docker-compose.document.test.yaml --env-file env-example-document -p tests up -d --build && docker compose -f docker-compose.document.test.yaml -p tests exec api /opt/wait-for-it.sh -t 0 localhost:3000 -- npm run test:e2e -- --watchAll --runInBand && docker compose -f docker-compose.document.test.yaml -p tests down && docker compose -p tests rm -svf",
     "test:e2e:relational:docker": "docker compose -f docker-compose.relational.test.yaml --env-file env-example-relational -p tests up -d --build && docker compose -f docker-compose.relational.test.yaml -p tests exec api /opt/wait-for-it.sh -t 0 localhost:3000 -- npm run test:e2e -- --watchAll --runInBand && docker compose -f docker-compose.relational.test.yaml -p tests down && docker compose -p tests rm -svf",
+    "test:mocha": "mocha -r ts-node/register test/mocha/**/*.spec.ts",
+    "test:playwright": "playwright test",
     "prepare": "is-ci || husky",
     "release": "release-it"
   },
@@ -138,7 +140,14 @@
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "tslib": "2.8.1",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "mocha": "10.4.0",
+    "chai": "4.3.10",
+    "sinon": "17.0.1",
+    "@types/mocha": "10.0.6",
+    "@types/chai": "4.3.11",
+    "@types/sinon": "10.0.17",
+    "playwright": "1.43.1"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './test/playwright',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${process.env.APP_PORT || 3000}`,
+  },
+});

--- a/test/mocha/templates.service.spec.ts
+++ b/test/mocha/templates.service.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TemplatesService } from '../../src/templates/templates.service';
+import { Repository } from 'typeorm';
+import { StandardClause } from '../../src/templates/entities/standard-clause.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('TemplatesService', () => {
+  let service: TemplatesService;
+  let repo: sinon.SinonStubbedInstance<Repository<StandardClause>>;
+
+  beforeEach(() => {
+    repo = {
+      create: sinon.stub(),
+      save: sinon.stub(),
+      find: sinon.stub(),
+      findOne: sinon.stub(),
+    } as unknown as sinon.SinonStubbedInstance<Repository<StandardClause>>;
+    service = new TemplatesService(repo as unknown as Repository<StandardClause>);
+  });
+
+  it('should create a clause', async () => {
+    const dto = { name: 'Test', type: 't', content: 'c' } as any;
+    const created = { id: '1', ...dto, isActive: true } as any;
+    (repo.create as any).returns(created);
+    (repo.save as any).resolves(created);
+
+    const result = await service.create(dto);
+
+    expect((repo.create as any).calledWith({ isActive: true, ...dto })).to.be.true;
+    expect((repo.save as any).calledWith(created)).to.be.true;
+    expect(result).to.equal(created);
+  });
+
+  it('should return one clause by id', async () => {
+    const clause = { id: '1' } as any;
+    (repo.findOne as any).resolves(clause);
+
+    const result = await service.findOne('1');
+
+    expect((repo.findOne as any).calledWith({ where: { id: '1', isActive: true } })).to.be.true;
+    expect(result).to.equal(clause);
+  });
+
+  it('should throw NotFoundException if clause not found', async () => {
+    (repo.findOne as any).resolves(null);
+
+    try {
+      await service.findOne('1');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).to.be.instanceOf(NotFoundException);
+    }
+  });
+});

--- a/test/playwright/templates.spec.ts
+++ b/test/playwright/templates.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Simple check that /templates endpoint is reachable
+
+test('should get templates list', async ({ request }) => {
+  const response = await request.get('/api/v1/templates');
+  expect(response.ok()).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add mocha unit tests for templates service
- add Playwright API test for templates endpoint
- include Mocha, Chai, Sinon, and Playwright dev dependencies
- add Playwright configuration

## Testing
- `npm install` *(fails: cannot fetch packages)*
- `npm run lint -- --fix` *(fails: module not found)*
- `npm test` *(fails: jest not installed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new npm scripts to run Mocha and Playwright tests.
  - Added Playwright configuration for flexible test environment setup.

- **Tests**
  - Added Mocha-based unit tests for template service functionality.
  - Added Playwright-based API test for the templates endpoint.

- **Chores**
  - Added new testing dependencies for Mocha, Chai, Sinon, and Playwright.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->