### PR TITLE
Add templates service tests

### DIFF
--- a/src/templates/templates.service.spec.ts
+++ b/src/templates/templates.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { TemplatesService } from './templates.service';
+import { StandardClause } from './entities/standard-clause.entity';
+import { CreateStandardClauseDto } from './dto/create-standard-clause.dto';
+import { UpdateStandardClauseDto } from './dto/update-standard-clause.dto';
+
+describe('TemplatesService', () => {
+  let service: TemplatesService;
+  let repository: jest.Mocked<Repository<StandardClause>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TemplatesService,
+        {
+          provide: getRepositoryToken(StandardClause),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(TemplatesService);
+    repository = module.get(getRepositoryToken(StandardClause));
+  });
+
+  describe('create', () => {
+    it('should create a standard clause', async () => {
+      const dto: CreateStandardClauseDto = {
+        name: 'Test',
+        type: 'NDA',
+        content: 'Text',
+      } as CreateStandardClauseDto;
+      const created: StandardClause = {
+        id: '1',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...dto,
+      } as StandardClause;
+
+      repository.create.mockReturnValue(created);
+      repository.save.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(repository.create).toHaveBeenCalledWith({ isActive: true, ...dto });
+      expect(repository.save).toHaveBeenCalledWith(created);
+      expect(result).toBe(created);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a clause by id', async () => {
+      const clause = { id: '1' } as StandardClause;
+      repository.findOne.mockResolvedValue(clause);
+
+      const result = await service.findOne('1');
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: '1', isActive: true },
+      });
+      expect(result).toBe(clause);
+    });
+
+    it('should throw NotFoundException if clause does not exist', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('2')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a clause', async () => {
+      const clause = { id: '1', name: 'A' } as StandardClause;
+      const dto: UpdateStandardClauseDto = { name: 'B' } as UpdateStandardClauseDto;
+
+      repository.findOne.mockResolvedValue(clause);
+      repository.save.mockImplementation(async (value) => value as StandardClause);
+
+      const result = await service.update('1', dto);
+
+      expect(repository.save).toHaveBeenCalledWith({ ...clause, ...dto });
+      expect(result).toEqual({ ...clause, ...dto });
+    });
+  });
+
+  describe('remove', () => {
+    it('should mark a clause as inactive', async () => {
+      const clause = { id: '1', isActive: true } as StandardClause;
+
+      repository.findOne.mockResolvedValue(clause);
+      repository.save.mockResolvedValue({ ...clause, isActive: false });
+
+      await service.remove('1');
+
+      expect(repository.save).toHaveBeenCalledWith({ ...clause, isActive: false });
+    });
+  });
+
+  describe('findByType', () => {
+    it('should return clauses by type', async () => {
+      const clauses = [{ id: '1' }] as StandardClause[];
+      repository.find.mockResolvedValue(clauses);
+
+      const result = await service.findByType('NDA');
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { type: 'NDA', isActive: true },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toBe(clauses);
+    });
+  });
+
+  describe('findByJurisdiction', () => {
+    it('should return clauses by jurisdiction', async () => {
+      const clauses = [{ id: '1' }] as StandardClause[];
+      repository.find.mockResolvedValue(clauses);
+
+      const result = await service.findByJurisdiction('US');
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { jurisdiction: 'US', isActive: true },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toBe(clauses);
+    });
+  });
+});

--- a/src/templates/templates.service.spec.ts
+++ b/src/templates/templates.service.spec.ts
@@ -51,7 +51,10 @@ describe('TemplatesService', () => {
 
       const result = await service.create(dto);
 
-      expect(repository.create).toHaveBeenCalledWith({ isActive: true, ...dto });
+      expect(repository.create).toHaveBeenCalledWith({
+        isActive: true,
+        ...dto,
+      });
       expect(repository.save).toHaveBeenCalledWith(created);
       expect(result).toBe(created);
     });
@@ -73,22 +76,36 @@ describe('TemplatesService', () => {
     it('should throw NotFoundException if clause does not exist', async () => {
       repository.findOne.mockResolvedValue(null);
 
-      await expect(service.findOne('2')).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.findOne('2')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
   });
 
   describe('update', () => {
     it('should update a clause', async () => {
       const clause = { id: '1', name: 'A' } as StandardClause;
-      const dto: UpdateStandardClauseDto = { name: 'B' } as UpdateStandardClauseDto;
+      const dto: UpdateStandardClauseDto = {
+        name: 'B',
+      } as UpdateStandardClauseDto;
 
       repository.findOne.mockResolvedValue(clause);
-      repository.save.mockImplementation(async (value) => value as StandardClause);
+      repository.save.mockImplementation(
+        async (value) => (await value) as StandardClause,
+      );
 
       const result = await service.update('1', dto);
 
       expect(repository.save).toHaveBeenCalledWith({ ...clause, ...dto });
       expect(result).toEqual({ ...clause, ...dto });
+    });
+
+    it('should throw NotFoundException if clause does not exist', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update('nonexistent', { name: 'New Name' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
   });
 
@@ -101,7 +118,18 @@ describe('TemplatesService', () => {
 
       await service.remove('1');
 
-      expect(repository.save).toHaveBeenCalledWith({ ...clause, isActive: false });
+      expect(repository.save).toHaveBeenCalledWith({
+        ...clause,
+        isActive: false,
+      });
+    });
+
+    it('should throw NotFoundException if clause does not exist', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      await expect(service.remove('nonexistent')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- add unit tests for templates service

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm run lint -- --fix` *(fails: cannot find module '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive tests for the main features of the TemplatesService, including creating, updating, retrieving, and removing standard clauses, as well as filtering by type and jurisdiction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->