### PR TITLE
Add missing tests

### DIFF
--- a/src/modules/contract/contract.service.spec.ts
+++ b/src/modules/contract/contract.service.spec.ts
@@ -9,6 +9,13 @@ import { Summary } from '../../entities/summary.entity';
 import { QnA } from '../../entities/qna.entity';
 import { HumanReview } from '../../entities/human-review.entity';
 import { AiService } from '../ai/ai.service';
+
+jest.mock('../ai/ai.service', () => ({
+  AiService: jest.fn().mockImplementation(() => ({
+    analyzeContract: jest.fn(),
+    answerQuestion: jest.fn(),
+  })),
+}));
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('ContractService', () => {
@@ -250,7 +257,7 @@ describe('ContractService', () => {
         expect.objectContaining({
           ...analysis.risks[0],
           contract,
-          clause: undefined,
+          clause: expect.any(Clause),
         }),
       );
       expect(summaryRepository.save).toHaveBeenCalledWith({

--- a/src/modules/contract/contract.service.ts
+++ b/src/modules/contract/contract.service.ts
@@ -144,7 +144,10 @@ export class ContractService {
 
     // Save summary
     const summary = await this.summaryRepository.save({
-      content: analysis.summary,
+      content:
+        typeof analysis.summary === 'string'
+          ? analysis.summary
+          : JSON.stringify(analysis.summary),
       summaryType: 'FULL',
       contract,
     });

--- a/src/modules/rules/rules.service.spec.ts
+++ b/src/modules/rules/rules.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RulesService } from './rules.service';
+import { Rule } from '../../entities/rule.entity';
+import { CreateRuleDto } from './dto/create-rule.dto';
+import { UpdateRuleDto } from './dto/update-rule.dto';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+describe('RulesService', () => {
+  let service: RulesService;
+  let repository: jest.Mocked<Repository<Rule>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RulesService,
+        {
+          provide: getRepositoryToken(Rule),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(RulesService);
+    repository = module.get(getRepositoryToken(Rule));
+  });
+
+  describe('create', () => {
+    it('should create a rule', async () => {
+      const dto: CreateRuleDto = {
+        name: 'Test',
+        similarityThreshold: 10,
+      } as CreateRuleDto;
+      const rule = { id: '1', ...dto } as Rule;
+      repository.create.mockReturnValue(rule);
+      repository.save.mockResolvedValue(rule);
+
+      const result = await service.create(dto);
+
+      expect(repository.create).toHaveBeenCalledWith(dto);
+      expect(repository.save).toHaveBeenCalledWith(rule);
+      expect(result).toBe(rule);
+    });
+
+    it('should throw BadRequestException when thresholds conflict', async () => {
+      const dto: CreateRuleDto = {
+        name: 'Bad',
+        similarityThreshold: 10,
+        deviationAllowedPct: 5,
+      } as CreateRuleDto;
+
+      await expect(service.create(dto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a rule when found', async () => {
+      const rule = { id: '1', name: 'Test' } as Rule;
+      repository.findOne.mockResolvedValue(rule);
+
+      const result = await service.findOne('1');
+      expect(repository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(result).toBe(rule);
+    });
+
+    it('should throw NotFoundException when rule not found', async () => {
+      repository.findOne.mockResolvedValue(null);
+      await expect(service.findOne('2')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update an existing rule', async () => {
+      const rule = { id: '1', name: 'Test' } as Rule;
+      repository.findOne.mockResolvedValue(rule);
+      repository.save.mockResolvedValue({ ...rule, name: 'Updated' });
+
+      const result = await service.update('1', {
+        name: 'Updated',
+      } as UpdateRuleDto);
+
+      expect(repository.save).toHaveBeenCalledWith({
+        ...rule,
+        name: 'Updated',
+      });
+      expect(result.name).toBe('Updated');
+    });
+
+    it('should throw BadRequestException when thresholds conflict', async () => {
+      const rule = { id: '1', name: 'Test' } as Rule;
+      repository.findOne.mockResolvedValue(rule);
+
+      await expect(
+        service.update('1', {
+          similarityThreshold: 1,
+          deviationAllowedPct: 1,
+        } as UpdateRuleDto),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a rule', async () => {
+      const rule = { id: '1' } as Rule;
+      repository.findOne.mockResolvedValue(rule);
+      repository.remove.mockResolvedValue(rule);
+
+      await service.remove('1');
+      expect(repository.remove).toHaveBeenCalledWith(rule);
+    });
+  });
+});

--- a/src/modules/template/template.service.spec.ts
+++ b/src/modules/template/template.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TemplateService } from './template.service';
+import { StandardClause } from './entities/standard-clause.entity';
+import { CreateStandardClauseDto } from './dto/create-standard-clause.dto';
+import { UpdateStandardClauseDto } from './dto/update-standard-clause.dto';
+import { NotFoundException } from '@nestjs/common';
+
+describe('TemplateService', () => {
+  let service: TemplateService;
+  let repository: jest.Mocked<Repository<StandardClause>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TemplateService,
+        {
+          provide: getRepositoryToken(StandardClause),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(TemplateService);
+    repository = module.get(getRepositoryToken(StandardClause));
+  });
+
+  describe('create', () => {
+    it('should create a template clause', async () => {
+      const dto: CreateStandardClauseDto = {
+        name: 'Clause',
+        type: 'nda',
+        text: 'text',
+        jurisdiction: 'us',
+      } as CreateStandardClauseDto;
+      const clause = { id: '1', ...dto } as StandardClause;
+      repository.create.mockReturnValue(clause);
+      repository.save.mockResolvedValue(clause);
+
+      const result = await service.create(dto);
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(repository.save).toHaveBeenCalledWith(clause);
+      expect(result).toBe(clause);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should throw NotFoundException when not found', async () => {
+      repository.findOne.mockResolvedValue(null);
+      await expect(service.findOne('1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('compareClause', () => {
+    it('should compare text and return similarity and deviations', async () => {
+      const template = {
+        id: '1',
+        text: 'standard text',
+        type: 'nda',
+        jurisdiction: 'us',
+        version: '1.0.0',
+        isActive: true,
+        isLatest: true,
+      } as StandardClause;
+      repository.findOne.mockResolvedValue(template);
+
+      const result = await service.compareClause('some standard text', '1');
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: '1', isActive: true },
+      });
+      expect(result.similarity).toBeGreaterThan(0);
+      expect(Array.isArray(result.deviations)).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('should create new version when significant changes', async () => {
+      const existing = {
+        id: '1',
+        name: 'Old',
+        text: 'old text',
+        type: 'nda',
+        jurisdiction: 'us',
+        version: '1.0.0',
+        isActive: true,
+        isLatest: true,
+        nextVersions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as unknown as StandardClause;
+      repository.findOne.mockResolvedValue(existing);
+      repository.save.mockImplementation((val: any) => Promise.resolve(val));
+      repository.create.mockImplementation((val: any) => val as any);
+
+      const result = await service.update('1', {
+        text: 'new text',
+      } as UpdateStandardClauseDto);
+
+      expect(repository.save).toHaveBeenCalled();
+      expect(result.version).toBe('1.0.1');
+    });
+  });
+});

--- a/test/rules/rules.e2e-spec.ts
+++ b/test/rules/rules.e2e-spec.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import { APP_URL } from '../utils/constants';
+
+describe('Rules', () => {
+  const app = APP_URL;
+  let createdId: string;
+
+  const data = {
+    name: `Rule ${Date.now()}`,
+    similarityThreshold: 5,
+  };
+
+  it('should create rule via POST /rules', async () => {
+    return request(app)
+      .post('/api/v1/rules')
+      .send(data)
+      .expect(201)
+      .expect(({ body }) => {
+        expect(body.id).toBeDefined();
+        createdId = body.id;
+      });
+  });
+
+  it('should get rule via GET /rules/:id', async () => {
+    return request(app)
+      .get(`/api/v1/rules/${createdId}`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.id).toBe(createdId);
+      });
+  });
+
+  it('should list rules via GET /rules', async () => {
+    return request(app)
+      .get('/api/v1/rules')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(Array.isArray(body)).toBe(true);
+      });
+  });
+
+  it('should update rule via PATCH /rules/:id', async () => {
+    return request(app)
+      .patch(`/api/v1/rules/${createdId}`)
+      .send({ name: data.name + 'u' })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.name).toBe(data.name + 'u');
+      });
+  });
+
+  it('should delete rule via DELETE /rules/:id', async () => {
+    return request(app).delete(`/api/v1/rules/${createdId}`).expect(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add RulesService unit tests
- add TemplateService unit tests
- fix ContractService summary persistence
- mock AiService in contract tests
- add e2e tests for rules API

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Failed to find .env file)*