### PR TITLE
Add missing tests for analysis and standard clauses modules

### DIFF
--- a/src/modules/analysis/analysis.service.spec.ts
+++ b/src/modules/analysis/analysis.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnalysisService } from './analysis.service';
+jest.mock('./ai.service', () => ({ AiService: jest.fn() }));
+import { AiService } from './ai.service';
+import {
+  Contract,
+  ContractStatus,
+  ContractType,
+} from './entities/contract.entity';
+import { Clause } from './entities/clause.entity';
+import { RiskFlag } from './entities/risk-flag.entity';
+import { Summary } from './entities/summary.entity';
+import { QnA } from './entities/qna.entity';
+import { HumanReview } from './entities/human-review.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('AnalysisService', () => {
+  let service: AnalysisService;
+  let contractRepo: jest.Mocked<Repository<Contract>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalysisService,
+        { provide: AiService, useValue: {} },
+        {
+          provide: getRepositoryToken(Contract),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        { provide: getRepositoryToken(Clause), useValue: {} },
+        { provide: getRepositoryToken(RiskFlag), useValue: {} },
+        { provide: getRepositoryToken(Summary), useValue: {} },
+        { provide: getRepositoryToken(QnA), useValue: {} },
+        { provide: getRepositoryToken(HumanReview), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(AnalysisService);
+    contractRepo = module.get(getRepositoryToken(Contract));
+  });
+
+  describe('createContract', () => {
+    it('should create and save a contract with pending status', async () => {
+      const dto = { title: 'Test', type: ContractType.NDA } as any;
+      const created = {
+        id: '1',
+        status: ContractStatus.PENDING_REVIEW,
+      } as Contract;
+
+      (contractRepo.create as jest.Mock).mockReturnValue(created);
+      (contractRepo.save as jest.Mock).mockResolvedValue(created);
+
+      const result = await service.createContract(dto);
+
+      expect(contractRepo.create).toHaveBeenCalledWith({
+        ...dto,
+        status: ContractStatus.PENDING_REVIEW,
+      });
+      expect(contractRepo.save).toHaveBeenCalledWith(created);
+      expect(result).toBe(created);
+    });
+  });
+
+  describe('findContract', () => {
+    it('should return contract when found', async () => {
+      const contract = { id: '1' } as Contract;
+      (contractRepo.findOne as jest.Mock).mockResolvedValue(contract);
+
+      const result = await service.findContract('1');
+
+      expect(contractRepo.findOne).toHaveBeenCalled();
+      expect(result).toBe(contract);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      (contractRepo.findOne as jest.Mock).mockResolvedValue(undefined);
+
+      await expect(service.findContract('2')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/modules/standard-clauses/standard-clauses.service.spec.ts
+++ b/src/modules/standard-clauses/standard-clauses.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StandardClausesService } from './standard-clauses.service';
+import { StandardClause } from '../../entities/standard-clause.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('StandardClausesService', () => {
+  let service: StandardClausesService;
+  let repo: jest.Mocked<Repository<StandardClause>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StandardClausesService,
+        {
+          provide: getRepositoryToken(StandardClause),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(StandardClausesService);
+    repo = module.get(getRepositoryToken(StandardClause));
+  });
+
+  describe('create', () => {
+    it('should create and save clause', async () => {
+      const dto = {
+        name: 'A',
+        type: 't',
+        contractType: 'c',
+        text: 'txt',
+      } as any;
+      const entity = { id: 1, ...dto } as StandardClause;
+      (repo.create as jest.Mock).mockReturnValue(entity);
+      (repo.save as jest.Mock).mockResolvedValue(entity);
+
+      const result = await service.create(dto);
+
+      expect(repo.create).toHaveBeenCalledWith(dto);
+      expect(repo.save).toHaveBeenCalledWith(entity);
+      expect(result).toBe(entity);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return clause when found', async () => {
+      const clause = { id: 1 } as StandardClause;
+      (repo.findOne as jest.Mock).mockResolvedValue(clause);
+
+      const result = await service.findOne(1);
+
+      expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(result).toBe(clause);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      (repo.findOne as jest.Mock).mockResolvedValue(undefined);
+
+      await expect(service.findOne(2)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete clause', async () => {
+      (repo.delete as jest.Mock).mockResolvedValue({ affected: 1 });
+      await service.remove(1);
+      expect(repo.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw NotFoundException when nothing deleted', async () => {
+      (repo.delete as jest.Mock).mockResolvedValue({ affected: 0 });
+      await expect(service.remove(1)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/src/types/langchain.d.ts
+++ b/src/types/langchain.d.ts
@@ -1,0 +1,5 @@
+declare module 'langchain/chains/conversational_retrieval_chain' {
+  export class ConversationalRetrievalQAChain {
+    static fromLLM(...args: any[]): any;
+  }
+}

--- a/test/analysis/analysis.e2e-spec.ts
+++ b/test/analysis/analysis.e2e-spec.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import { APP_URL } from '../utils/constants';
+
+describe('Analysis', () => {
+  const app = APP_URL;
+  let createdId: string;
+
+  it('should create contract via POST /analysis/contracts', async () => {
+    return request(app)
+      .post('/api/v1/analysis/contracts')
+      .send({ title: 'Test Contract', type: 'other' })
+      .expect(201)
+      .expect(({ body }) => {
+        expect(body.id).toBeDefined();
+        createdId = body.id;
+      });
+  });
+
+  it('should get contract via GET /analysis/contracts/:id', async () => {
+    return request(app)
+      .get(`/api/v1/analysis/contracts/${createdId}`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.id).toBe(createdId);
+      });
+  });
+});

--- a/test/standard-clauses/standard-clauses.e2e-spec.ts
+++ b/test/standard-clauses/standard-clauses.e2e-spec.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import { APP_URL, ADMIN_EMAIL, ADMIN_PASSWORD } from '../utils/constants';
+
+describe('Standard Clauses', () => {
+  const app = APP_URL;
+  let token: string;
+  let createdId: number;
+
+  beforeAll(async () => {
+    await request(app)
+      .post('/api/v1/auth/email/login')
+      .send({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD })
+      .then(({ body }) => {
+        token = body.token;
+      });
+  });
+
+  it('should create clause via POST /standard-clauses', async () => {
+    return request(app)
+      .post('/api/v1/standard-clauses')
+      .auth(token, { type: 'bearer' })
+      .send({
+        name: 'Test Clause',
+        type: 'general',
+        contractType: 'other',
+        text: 'sample',
+      })
+      .expect(201)
+      .expect(({ body }) => {
+        expect(body.id).toBeDefined();
+        createdId = body.id;
+      });
+  });
+
+  it('should get clause via GET /standard-clauses/:id', async () => {
+    return request(app)
+      .get(`/api/v1/standard-clauses/${createdId}`)
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.id).toBe(createdId);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AnalysisService and StandardClausesService
- create simple e2e tests for analysis and standard-clause endpoints
- stub unsupported langchain type

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Failed to find .env file)*