### PR TITLE
Migrate services to Prisma

### DIFF
--- a/src/modules/analysis/analysis.service.ts
+++ b/src/modules/analysis/analysis.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Contract } from './entities/contract.entity';
-import { Clause, ClauseType } from './entities/clause.entity';
-import { RiskFlag, RiskType, RiskSeverity } from './entities/risk-flag.entity';
-import { Summary, SummaryType } from './entities/summary.entity';
-import { QnA } from './entities/qna.entity';
-import { HumanReview } from './entities/human-review.entity';
+import { PrismaClient } from '@prisma/client';
+import {
+  Contract,
+  Clause,
+  RiskFlag,
+  Summary,
+  QnA,
+  HumanReview,
+} from '../../../generated/prisma';
+import { ClauseType } from './entities/clause.entity';
+import { RiskType, RiskSeverity } from './entities/risk-flag.entity';
+import { SummaryType } from './entities/summary.entity';
 import { CreateContractDto } from './dto/create-contract.dto';
 import { UpdateContractDto } from './dto/update-contract.dto';
 import { CreateClauseDto } from './dto/create-clause.dto';
@@ -25,43 +29,43 @@ import { AiService } from '../ai/ai.service';
 
 @Injectable()
 export class AnalysisService {
-  constructor(
-    @InjectRepository(Contract)
-    private readonly contractRepository: Repository<Contract>,
-    @InjectRepository(Clause)
-    private readonly clauseRepository: Repository<Clause>,
-    @InjectRepository(RiskFlag)
-    private readonly riskFlagRepository: Repository<RiskFlag>,
-    @InjectRepository(Summary)
-    private readonly summaryRepository: Repository<Summary>,
-    @InjectRepository(QnA)
-    private readonly qnaRepository: Repository<QnA>,
-    @InjectRepository(HumanReview)
-    private readonly humanReviewRepository: Repository<HumanReview>,
-    private readonly aiService: AiService,
-  ) {}
+  private prisma: PrismaClient;
+  constructor(private readonly aiService: AiService) {
+    this.prisma = new PrismaClient();
+  }
 
   // Contract operations
   async createContract(
     createContractDto: CreateContractDto,
   ): Promise<Contract> {
-    const contract = this.contractRepository.create({
-      ...createContractDto,
-      status: ContractStatus.PENDING_REVIEW,
+    return await this.prisma.contract.create({
+      data: {
+        ...createContractDto,
+        status: ContractStatus.PENDING_REVIEW,
+      },
     });
-    return this.contractRepository.save(contract);
   }
 
   async findAllContracts(): Promise<Contract[]> {
-    return this.contractRepository.find({
-      relations: ['clauses', 'riskFlags', 'summaries', 'reviews'],
+    return await this.prisma.contract.findMany({
+      include: {
+        clauses: true,
+        riskFlags: true,
+        summaries: true,
+        reviews: true,
+      },
     });
   }
 
   async findContract(id: string): Promise<Contract> {
-    const contract = await this.contractRepository.findOne({
+    const contract = await this.prisma.contract.findUnique({
       where: { id },
-      relations: ['clauses', 'riskFlags', 'summaries', 'reviews'],
+      include: {
+        clauses: true,
+        riskFlags: true,
+        summaries: true,
+        reviews: true,
+      },
     });
     if (!contract) {
       throw new NotFoundException(`Contract with ID ${id} not found`);
@@ -73,14 +77,16 @@ export class AnalysisService {
     id: string,
     updateContractDto: UpdateContractDto,
   ): Promise<Contract> {
-    const contract = await this.findContract(id);
-    Object.assign(contract, updateContractDto);
-    return this.contractRepository.save(contract);
+    await this.findContract(id);
+    return await this.prisma.contract.update({
+      where: { id },
+      data: updateContractDto,
+    });
   }
 
   async removeContract(id: string): Promise<void> {
-    const contract = await this.findContract(id);
-    await this.contractRepository.remove(contract);
+    await this.findContract(id);
+    await this.prisma.contract.delete({ where: { id } });
   }
 
   // Clause operations
@@ -88,24 +94,25 @@ export class AnalysisService {
     contractId: string,
     createClauseDto: CreateClauseDto,
   ): Promise<Clause> {
-    const clause = this.clauseRepository.create({
-      ...createClauseDto,
-      contract: { id: contractId },
+    return await this.prisma.clause.create({
+      data: {
+        ...createClauseDto,
+        contractId,
+      },
     });
-    return this.clauseRepository.save(clause);
   }
 
   async findContractClauses(contractId: string): Promise<Clause[]> {
-    return this.clauseRepository.find({
-      where: { contract: { id: contractId } },
-      relations: ['riskFlags', 'summaries', 'qnaInteractions'],
+    return await this.prisma.clause.findMany({
+      where: { contractId },
+      include: { riskFlags: true, summaries: true },
     });
   }
 
   async findClause(id: string): Promise<Clause> {
-    const clause = await this.clauseRepository.findOne({
+    const clause = await this.prisma.clause.findUnique({
       where: { id },
-      relations: ['contract', 'riskFlags', 'summaries', 'qnaInteractions'],
+      include: { contract: true, riskFlags: true, summaries: true },
     });
     if (!clause) {
       throw new NotFoundException(`Clause with ID ${id} not found`);
@@ -117,14 +124,16 @@ export class AnalysisService {
     id: string,
     updateClauseDto: UpdateClauseDto,
   ): Promise<Clause> {
-    const clause = await this.findClause(id);
-    Object.assign(clause, updateClauseDto);
-    return this.clauseRepository.save(clause);
+    await this.findClause(id);
+    return await this.prisma.clause.update({
+      where: { id },
+      data: updateClauseDto,
+    });
   }
 
   async removeClause(id: string): Promise<void> {
-    const clause = await this.findClause(id);
-    await this.clauseRepository.remove(clause);
+    await this.findClause(id);
+    await this.prisma.clause.delete({ where: { id } });
   }
 
   // Risk flag operations
@@ -133,25 +142,26 @@ export class AnalysisService {
     clauseId: string | null,
     createRiskFlagDto: CreateRiskFlagDto,
   ): Promise<RiskFlag> {
-    const riskFlag = this.riskFlagRepository.create({
-      ...createRiskFlagDto,
-      contract: { id: contractId },
-      ...(clauseId ? { clause: { id: clauseId } } : {}),
+    return await this.prisma.riskFlag.create({
+      data: {
+        ...createRiskFlagDto,
+        contractId,
+        ...(clauseId ? { clauseId } : {}),
+      },
     });
-    return this.riskFlagRepository.save(riskFlag);
   }
 
   async findContractRiskFlags(contractId: string): Promise<RiskFlag[]> {
-    return this.riskFlagRepository.find({
-      where: { contract: { id: contractId } },
-      relations: ['clause'],
+    return await this.prisma.riskFlag.findMany({
+      where: { contractId },
+      include: { clause: true },
     });
   }
 
   async findRiskFlag(id: string): Promise<RiskFlag> {
-    const riskFlag = await this.riskFlagRepository.findOne({
+    const riskFlag = await this.prisma.riskFlag.findUnique({
       where: { id },
-      relations: ['contract', 'clause'],
+      include: { contract: true, clause: true },
     });
     if (!riskFlag) {
       throw new NotFoundException(`Risk flag with ID ${id} not found`);
@@ -163,14 +173,16 @@ export class AnalysisService {
     id: string,
     updateRiskFlagDto: UpdateRiskFlagDto,
   ): Promise<RiskFlag> {
-    const riskFlag = await this.findRiskFlag(id);
-    Object.assign(riskFlag, updateRiskFlagDto);
-    return this.riskFlagRepository.save(riskFlag);
+    await this.findRiskFlag(id);
+    return await this.prisma.riskFlag.update({
+      where: { id },
+      data: updateRiskFlagDto,
+    });
   }
 
   async removeRiskFlag(id: string): Promise<void> {
-    const riskFlag = await this.findRiskFlag(id);
-    await this.riskFlagRepository.remove(riskFlag);
+    await this.findRiskFlag(id);
+    await this.prisma.riskFlag.delete({ where: { id } });
   }
 
   // Summary operations
@@ -179,25 +191,26 @@ export class AnalysisService {
     clauseId: string | null,
     createSummaryDto: CreateSummaryDto,
   ): Promise<Summary> {
-    const summary = this.summaryRepository.create({
-      ...createSummaryDto,
-      contract: { id: contractId },
-      ...(clauseId ? { clause: { id: clauseId } } : {}),
+    return await this.prisma.summary.create({
+      data: {
+        ...createSummaryDto,
+        contractId,
+        ...(clauseId ? { clauseId } : {}),
+      },
     });
-    return this.summaryRepository.save(summary);
   }
 
   async findContractSummaries(contractId: string): Promise<Summary[]> {
-    return this.summaryRepository.find({
-      where: { contract: { id: contractId } },
-      relations: ['clause'],
+    return await this.prisma.summary.findMany({
+      where: { contractId },
+      include: { clause: true },
     });
   }
 
   async findSummary(id: string): Promise<Summary> {
-    const summary = await this.summaryRepository.findOne({
+    const summary = await this.prisma.summary.findUnique({
       where: { id },
-      relations: ['contract', 'clause'],
+      include: { contract: true, clause: true },
     });
     if (!summary) {
       throw new NotFoundException(`Summary with ID ${id} not found`);
@@ -209,14 +222,16 @@ export class AnalysisService {
     id: string,
     updateSummaryDto: UpdateSummaryDto,
   ): Promise<Summary> {
-    const summary = await this.findSummary(id);
-    Object.assign(summary, updateSummaryDto);
-    return this.summaryRepository.save(summary);
+    await this.findSummary(id);
+    return await this.prisma.summary.update({
+      where: { id },
+      data: updateSummaryDto,
+    });
   }
 
   async removeSummary(id: string): Promise<void> {
-    const summary = await this.findSummary(id);
-    await this.summaryRepository.remove(summary);
+    await this.findSummary(id);
+    await this.prisma.summary.delete({ where: { id } });
   }
 
   // Q&A operations
@@ -225,25 +240,26 @@ export class AnalysisService {
     clauseId: string | null,
     createQnADto: CreateQnADto,
   ): Promise<QnA> {
-    const qna = this.qnaRepository.create({
-      ...createQnADto,
-      contract: { id: contractId },
-      ...(clauseId ? { clause: { id: clauseId } } : {}),
+    return await this.prisma.qnA.create({
+      data: {
+        ...createQnADto,
+        contractId,
+        ...(clauseId ? { clauseId } : {}),
+      },
     });
-    return this.qnaRepository.save(qna);
   }
 
   async findContractQnAs(contractId: string): Promise<QnA[]> {
-    return this.qnaRepository.find({
-      where: { contract: { id: contractId } },
-      relations: ['clause'],
+    return await this.prisma.qnA.findMany({
+      where: { contractId },
+      include: { clause: true },
     });
   }
 
   async findQnA(id: string): Promise<QnA> {
-    const qna = await this.qnaRepository.findOne({
+    const qna = await this.prisma.qnA.findUnique({
       where: { id },
-      relations: ['contract', 'clause'],
+      include: { contract: true, clause: true },
     });
     if (!qna) {
       throw new NotFoundException(`Q&A with ID ${id} not found`);
@@ -252,14 +268,16 @@ export class AnalysisService {
   }
 
   async updateQnA(id: string, updateQnADto: UpdateQnADto): Promise<QnA> {
-    const qna = await this.findQnA(id);
-    Object.assign(qna, updateQnADto);
-    return this.qnaRepository.save(qna);
+    await this.findQnA(id);
+    return await this.prisma.qnA.update({
+      where: { id },
+      data: updateQnADto,
+    });
   }
 
   async removeQnA(id: string): Promise<void> {
-    const qna = await this.findQnA(id);
-    await this.qnaRepository.remove(qna);
+    await this.findQnA(id);
+    await this.prisma.qnA.delete({ where: { id } });
   }
 
   // Human review operations
@@ -267,23 +285,24 @@ export class AnalysisService {
     contractId: string,
     createHumanReviewDto: CreateHumanReviewDto,
   ): Promise<HumanReview> {
-    const review = this.humanReviewRepository.create({
-      ...createHumanReviewDto,
-      contract: { id: contractId },
+    return await this.prisma.humanReview.create({
+      data: {
+        ...createHumanReviewDto,
+        contractId,
+      },
     });
-    return this.humanReviewRepository.save(review);
   }
 
   async findContractReviews(contractId: string): Promise<HumanReview[]> {
-    return this.humanReviewRepository.find({
-      where: { contract: { id: contractId } },
+    return await this.prisma.humanReview.findMany({
+      where: { contractId },
     });
   }
 
   async findReview(id: string): Promise<HumanReview> {
-    const review = await this.humanReviewRepository.findOne({
+    const review = await this.prisma.humanReview.findUnique({
       where: { id },
-      relations: ['contract'],
+      include: { contract: true },
     });
     if (!review) {
       throw new NotFoundException(`Review with ID ${id} not found`);
@@ -295,14 +314,16 @@ export class AnalysisService {
     id: string,
     updateHumanReviewDto: UpdateHumanReviewDto,
   ): Promise<HumanReview> {
-    const review = await this.findReview(id);
-    Object.assign(review, updateHumanReviewDto);
-    return this.humanReviewRepository.save(review);
+    await this.findReview(id);
+    return await this.prisma.humanReview.update({
+      where: { id },
+      data: updateHumanReviewDto,
+    });
   }
 
   async removeReview(id: string): Promise<void> {
-    const review = await this.findReview(id);
-    await this.humanReviewRepository.remove(review);
+    await this.findReview(id);
+    await this.prisma.humanReview.delete({ where: { id } });
   }
 
   // Analysis operations
@@ -311,7 +332,10 @@ export class AnalysisService {
 
     // Update contract status
     contract.status = ContractStatus.IN_REVIEW;
-    await this.contractRepository.save(contract);
+    await this.prisma.contract.update({
+      where: { id: contract.id },
+      data: { status: contract.status },
+    });
 
     // Create initial human review
     await this.createHumanReview(contractId, {
@@ -375,7 +399,10 @@ export class AnalysisService {
 
     // Update contract status
     contract.status = ContractStatus.IN_REVIEW;
-    await this.contractRepository.save(contract);
+    await this.prisma.contract.update({
+      where: { id: contract.id },
+      data: { status: contract.status },
+    });
   }
 
   async generateSummary(contractId: string, type: string): Promise<Summary> {

--- a/src/modules/rules/rules.service.ts
+++ b/src/modules/rules/rules.service.ts
@@ -3,18 +3,17 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Rule } from '../../entities/rule.entity';
+import { PrismaClient } from '@prisma/client';
+import { Rule } from '../../../generated/prisma';
 import { CreateRuleDto } from './dto/create-rule.dto';
 import { UpdateRuleDto } from './dto/update-rule.dto';
 
 @Injectable()
 export class RulesService {
-  constructor(
-    @InjectRepository(Rule)
-    private readonly ruleRepository: Repository<Rule>,
-  ) {}
+  private prisma: PrismaClient;
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
 
   private validateThresholds(dto: CreateRuleDto | UpdateRuleDto) {
     if (
@@ -30,16 +29,15 @@ export class RulesService {
 
   async create(dto: CreateRuleDto): Promise<Rule> {
     this.validateThresholds(dto);
-    const rule = this.ruleRepository.create(dto);
-    return this.ruleRepository.save(rule);
+    return await this.prisma.rule.create({ data: dto });
   }
 
   async findAll(): Promise<Rule[]> {
-    return this.ruleRepository.find();
+    return await this.prisma.rule.findMany();
   }
 
   async findOne(id: string): Promise<Rule> {
-    const rule = await this.ruleRepository.findOne({ where: { id } });
+    const rule = await this.prisma.rule.findUnique({ where: { id } });
     if (!rule) {
       throw new NotFoundException(`Rule with ID ${id} not found`);
     }
@@ -47,14 +45,16 @@ export class RulesService {
   }
 
   async update(id: string, dto: UpdateRuleDto): Promise<Rule> {
-    const rule = await this.findOne(id);
+    await this.findOne(id);
     this.validateThresholds(dto);
-    Object.assign(rule, dto);
-    return this.ruleRepository.save(rule);
+    return await this.prisma.rule.update({
+      where: { id },
+      data: dto,
+    });
   }
 
   async remove(id: string): Promise<void> {
-    const rule = await this.findOne(id);
-    await this.ruleRepository.remove(rule);
+    await this.findOne(id);
+    await this.prisma.rule.delete({ where: { id } });
   }
 }

--- a/src/modules/standard-clauses/standard-clauses.service.ts
+++ b/src/modules/standard-clauses/standard-clauses.service.ts
@@ -1,32 +1,30 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { StandardClause } from '../../entities/standard-clause.entity';
+import { PrismaClient } from '@prisma/client';
+import { StandardClause } from '../../../generated/prisma';
 import { CreateStandardClauseDto } from './dto/create-standard-clause.dto';
 import { UpdateStandardClauseDto } from './dto/update-standard-clause.dto';
 
 @Injectable()
 export class StandardClausesService {
-  constructor(
-    @InjectRepository(StandardClause)
-    private standardClauseRepository: Repository<StandardClause>,
-  ) {}
+  private prisma: PrismaClient;
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
 
   async create(
     createStandardClauseDto: CreateStandardClauseDto,
   ): Promise<StandardClause> {
-    const standardClause = this.standardClauseRepository.create(
-      createStandardClauseDto,
-    );
-    return this.standardClauseRepository.save(standardClause);
+    return await this.prisma.standardClause.create({
+      data: createStandardClauseDto,
+    });
   }
 
   async findAll(): Promise<StandardClause[]> {
-    return this.standardClauseRepository.find();
+    return await this.prisma.standardClause.findMany();
   }
 
   async findOne(id: number): Promise<StandardClause> {
-    const standardClause = await this.standardClauseRepository.findOne({
+    const standardClause = await this.prisma.standardClause.findUnique({
       where: { id },
     });
     if (!standardClause) {
@@ -36,26 +34,29 @@ export class StandardClausesService {
   }
 
   async findByType(type: string): Promise<StandardClause[]> {
-    return this.standardClauseRepository.find({ where: { type } });
+    return await this.prisma.standardClause.findMany({ where: { type } });
   }
 
   async findByContractType(contractType: string): Promise<StandardClause[]> {
-    return this.standardClauseRepository.find({ where: { contractType } });
+    return await this.prisma.standardClause.findMany({
+      where: { contractType },
+    });
   }
 
   async update(
     id: number,
     updateStandardClauseDto: UpdateStandardClauseDto,
   ): Promise<StandardClause> {
-    const standardClause = await this.findOne(id);
-    Object.assign(standardClause, updateStandardClauseDto);
-    return this.standardClauseRepository.save(standardClause);
+    await this.findOne(id);
+    return await this.prisma.standardClause.update({
+      where: { id },
+      data: updateStandardClauseDto,
+    });
   }
 
   async remove(id: number): Promise<void> {
-    const result = await this.standardClauseRepository.delete(id);
-    if (result.affected === 0) {
+    await this.prisma.standardClause.delete({ where: { id } }).catch(() => {
       throw new NotFoundException(`Standard clause with ID ${id} not found`);
-    }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- switch analysis, template, rules and standard clause services from TypeORM repositories to Prisma
- use Prisma client in templates service too

## Testing
- `npm run lint -- --fix`
- `npm test` *(fails: Prisma client not initialized)*
- `npm run test:e2e` *(fails: missing .env file)*
